### PR TITLE
Remove invalid 'hide' from font effects

### DIFF
--- a/DIODE_SMB.kicad_mod
+++ b/DIODE_SMB.kicad_mod
@@ -3,7 +3,7 @@
     (effects (font (size 1.016 1.016) (thickness 0.3048)))
   )
   (fp_text value CMSH3-60M (at 0 -4.064) (layer F.SilkS) hide
-    (effects (font (size 1.016 1.016) (thickness 0.3048)) hide)
+    (effects (font (size 1.016 1.016) (thickness 0.3048)))
   )
   (fp_line (start 3.556 -2.54) (end 3.556 2.54) (layer F.SilkS) (width 0.20066))
   (fp_line (start -3.048 2.286) (end 3.048 2.286) (layer F.SilkS) (width 0.20066))

--- a/RJ11-MOLEX.kicad_mod
+++ b/RJ11-MOLEX.kicad_mod
@@ -2,8 +2,8 @@
   (fp_text reference J4 (at 0.381 -11.049) (layer F.SilkS)
     (effects (font (size 0.889 0.762) (thickness 0.1524)))
   )
-  (fp_text value RJ11 (at 5.4102 -11.3792) (layer F.SilkS)
-    (effects (font (size 0.889 0.762) (thickness 0.1524)) hide)
+  (fp_text value RJ11 (at 5.4102 -11.3792) (layer F.SilkS) hide
+    (effects (font (size 0.889 0.762) (thickness 0.1524)))
   )
   (fp_line (start -6.604 -10.2362) (end -6.604 7.874) (layer F.SilkS) (width 0.1778))
   (fp_line (start 6.604 -10.2362) (end 6.604 7.874) (layer F.SilkS) (width 0.1778))


### PR DESCRIPTION
This was causing me a bit of an issue while testing [my parsing library](https://github.com/monostable/haskell-kicad-data). The `hide` inside the `effects` expression is invalid, KiCad simply ignores it and doesn't add it when you open and export these footprints (that's actually how I removed them).